### PR TITLE
feat: add type field to issues and pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ The following sets of tools are available (all are on by default):
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `title`: Issue title (string, required)
+  - `type`: Type of this issue (string, optional)
 
 - **get_issue** - Get issue details
   - `issue_number`: The number of the issue (number, required)
@@ -592,6 +593,7 @@ The following sets of tools are available (all are on by default):
   - `repo`: Repository name (string, required)
   - `state`: New state (string, optional)
   - `title`: New title (string, optional)
+  - `type`: New issue type (string, optional)
 
 </details>
 

--- a/pkg/github/__toolsnaps__/create_issue.snap
+++ b/pkg/github/__toolsnaps__/create_issue.snap
@@ -39,6 +39,10 @@
       "title": {
         "description": "Issue title",
         "type": "string"
+      },
+      "type": {
+        "description": "Type of this issue",
+        "type": "string"
       }
     },
     "required": [

--- a/pkg/github/__toolsnaps__/update_issue.snap
+++ b/pkg/github/__toolsnaps__/update_issue.snap
@@ -51,6 +51,10 @@
       "title": {
         "description": "New title",
         "type": "string"
+      },
+      "type": {
+        "description": "New issue type",
+        "type": "string"
       }
     },
     "required": [


### PR DESCRIPTION
- Add type parameter to create_issue and update_issue tools
- Add type parameter to create_pull_request and update_pull_request tools
- Update toolsnaps to reflect new type field support

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
